### PR TITLE
Updates outdated passed/failed rubric terms

### DIFF
--- a/docs/releases/v3.3.2/authors/assessment_lti_replace_result.html
+++ b/docs/releases/v3.3.2/authors/assessment_lti_replace_result.html
@@ -236,7 +236,7 @@
 
 <p>The <em><a href="/Obojobo-Docs/releases/v3.3.2/developers/obo_nodes/rubric.html">rubric</a></em> attributes can be configured to conditionally send scores when they are above a value.</p>
 
-<p>Set the <em><a href="/Obojobo-Docs/releases/v3.3.2/developers/obo_nodes/rubric.html">rubric</a></em> attribute <code class="highlighter-rouge">failingResult="no-score"</code> to prevent any score below the value of <code class="highlighter-rouge">passingAttemptScore</code> from being sent to the LMS.</p>
+<p>Set the <em><a href="/Obojobo-Docs/releases/v3.3.2/developers/obo_nodes/rubric.html">rubric</a></em> attribute <code class="highlighter-rouge">failedResult="no-score"</code> to prevent any score below the value of <code class="highlighter-rouge">passingAttemptScore</code> from being sent to the LMS.</p>
 
 <p>This can be useful when the assignment in the LMS is used to prevent access to other parts of the course. By not sending a score back, the LMS will not unlock content that requires a passing score.</p>
 
@@ -247,8 +247,8 @@
       <span class="nt">&lt;rubric</span>
         <span class="na">type=</span><span class="s">"pass-fail"</span>
         <span class="na">passingAttemptScore=</span><span class="s">"75"</span>
-        <span class="na">passingResult=</span><span class="s">"$attempt_score"</span>
-        <span class="na">failingResult=</span><span class="s">"no-score"</span>
+        <span class="na">passedResult=</span><span class="s">"$attempt_score"</span>
+        <span class="na">failedResult=</span><span class="s">"no-score"</span>
       <span class="nt">/&gt;</span>
 
       <span class="c">&lt;!-- ... --&gt;</span>
@@ -272,8 +272,8 @@
       <span class="nt">&lt;rubric</span>
         <span class="na">type=</span><span class="s">"pass-fail"</span>
         <span class="na">passingAttemptScore=</span><span class="s">"75"</span>
-        <span class="na">passingResult=</span><span class="s">"$attempt_score"</span>
-        <span class="na">failingResult=</span><span class="s">"no-score"</span>
+        <span class="na">passedResult=</span><span class="s">"$attempt_score"</span>
+        <span class="na">failedResult=</span><span class="s">"no-score"</span>
         <span class="na">unableToPassResult=</span><span class="s">"$highest_attempt_score"</span>
       <span class="nt">/&gt;</span>
 
@@ -303,8 +303,8 @@
       <span class="nt">&lt;rubric</span>
         <span class="na">type=</span><span class="s">"pass-fail"</span>
         <span class="na">passingAttemptScore=</span><span class="s">"75"</span>
-        <span class="na">passingResult=</span><span class="s">"$attempt_score"</span>
-        <span class="na">failingResult=</span><span class="s">"no-score"</span>
+        <span class="na">passedResult=</span><span class="s">"$attempt_score"</span>
+        <span class="na">failedResult=</span><span class="s">"no-score"</span>
         <span class="na">unableToPassResult=</span><span class="s">"$highest_attempt_score"</span>
       <span class="nt">/&gt;</span>
 
@@ -328,7 +328,7 @@
 
 <p>When failing with attempts remaining the <code class="highlighter-rouge">for="no-score"</code> is always matched.</p>
 
-<p><code class="highlighter-rouge">passingAttemptScore</code> is set to 75, and the <code class="highlighter-rouge">passingResult</code> is set to the <code class="highlighter-rouge">$attempt_score</code> variable. This means in a passing condition, the score will be <strong>75+</strong>, matching <code class="highlighter-rouge">for="[75,100]"</code>.</p>
+<p><code class="highlighter-rouge">passingAttemptScore</code> is set to 75, and the <code class="highlighter-rouge">passedResult</code> is set to the <code class="highlighter-rouge">$attempt_score</code> variable. This means in a passing condition, the score will be <strong>75+</strong>, matching <code class="highlighter-rouge">for="[75,100]"</code>.</p>
 
 <p>Failing with no attempts remaining won’t match <code class="highlighter-rouge">for="no-score"</code> because the <code class="highlighter-rouge">unableToPassResult</code> attribute is set to a variable that will report a score. This means that when the student runs out of attempts, failing every time, the score will be recorded based on their highest attempt score. This score will be 0-75, so the <code class="highlighter-rouge">for="[0,75)"</code> condition is matched.</p>
 

--- a/docs/releases/v3.3.2/authors/assessment_threshold_scoring.html
+++ b/docs/releases/v3.3.2/authors/assessment_threshold_scoring.html
@@ -10,12 +10,12 @@
   <title>Threshold Scoring - Obojobo Next Documentation</title>
   <meta name="viewport" content="width=device-width" />
   <meta name="generator" content="Docusaurus" />
-  <meta name="description" content="Assessment Rubric’s &#39;pass-fail&#39; type can optionally be used to create a threshold type scoring system.For example, an assessment can require a score of 75% or higher to pass. When the passingAttemptScore is reached, the student’s score will be adjusted to the passingResult value.In this example, ..." />
+  <meta name="description" content="Assessment Rubric’s &#39;pass-fail&#39; type can optionally be used to create a threshold type scoring system.For example, an assessment can require a score of 75% or higher to pass. When the passingAttemptScore is reached, the student’s score will be adjusted to the passedResult value.In this example, w..." />
   <meta name="docsearch:language" content="en" />
   <meta property="og:title" content="Threshold Scoring - Obojobo Next Documentation" />
   <meta property="og:type" content="website" />
   <meta property="og:url" content="https://ucfopen.github.io/Obojobo-Docs/releases/v3.3.2/authors/assessment_threshold_scoring.html" />
-  <meta property="og:description" content="Assessment Rubric’s &#39;pass-fail&#39; type can optionally be used to create a threshold type scoring system.For example, an assessment can require a score of 75% or higher to pass. When the passingAttemptScore is reached, the student’s score will be adjusted to the passingResult value.In this example, ..."
+  <meta property="og:description" content="Assessment Rubric’s &#39;pass-fail&#39; type can optionally be used to create a threshold type scoring system.For example, an assessment can require a score of 75% or higher to pass. When the passingAttemptScore is reached, the student’s score will be adjusted to the passedResult value.In this example, w..."
   />
   <meta name="twitter:card" content="summary" />
   <link rel="shortcut icon" href="/Obojobo-Docs/assets/images/favicon.ico" />
@@ -214,7 +214,7 @@
                 <span>
                   <p>Assessment Rubric’s <code class="highlighter-rouge">'pass-fail'</code> type can optionally be used to create a threshold type scoring system.</p>
 
-<p>For example, an assessment can require a score of 75% or higher to pass. When the <code class="highlighter-rouge">passingAttemptScore</code> is reached, the student’s score will be adjusted to the <code class="highlighter-rouge">passingResult</code> value.</p>
+<p>For example, an assessment can require a score of 75% or higher to pass. When the <code class="highlighter-rouge">passingAttemptScore</code> is reached, the student’s score will be adjusted to the <code class="highlighter-rouge">passedResult</code> value.</p>
 
 <p>In this example, when the student scores below 75%, the score will be adjusted to 0. When the student’s score is 75% or higher, the score will be adjusted to <code class="highlighter-rouge">100%</code>.</p>
 
@@ -226,8 +226,8 @@
       <span class="nt">&lt;rubric</span>
         <span class="na">type=</span><span class="s">"pass-fail"</span>
         <span class="na">passingAttemptScore=</span><span class="s">"75"</span>
-        <span class="na">passingResult=</span><span class="s">"100"</span>
-        <span class="na">failingResult=</span><span class="s">"0"</span>
+        <span class="na">passedResult=</span><span class="s">"100"</span>
+        <span class="na">failedResult=</span><span class="s">"0"</span>
       <span class="nt">/&gt;</span>
 
       <span class="c">&lt;!-- ... --&gt;</span>
@@ -244,8 +244,8 @@
       <span class="nt">&lt;rubric</span>
         <span class="na">type=</span><span class="s">"pass-fail"</span>
         <span class="na">passingAttemptScore=</span><span class="s">"75"</span>
-        <span class="na">passingResult=</span><span class="s">"100"</span>
-        <span class="na">failingResult=</span><span class="s">"0"</span>
+        <span class="na">passedResult=</span><span class="s">"100"</span>
+        <span class="na">failedResult=</span><span class="s">"0"</span>
       <span class="nt">/&gt;</span>
 
       <span class="nt">&lt;scoreActions&gt;</span>

--- a/docs/releases/v3.3.2/developers/obo_nodes/assessment.html
+++ b/docs/releases/v3.3.2/developers/obo_nodes/assessment.html
@@ -566,7 +566,7 @@
   <span class="nt">&lt;QuestionBank</span> <span class="na">choose=</span><span class="s">"3"</span> <span class="na">select=</span><span class="s">"random"</span><span class="nt">&gt;</span>
     <span class="c">&lt;!-- ... --&gt;</span>
   <span class="nt">&lt;/QuestionBank&gt;</span>
-  <span class="nt">&lt;rubric</span> <span class="na">type=</span><span class="s">"pass-fail"</span> <span class="na">passingAttemptScore=</span><span class="s">"80"</span> <span class="na">passingResult=</span><span class="s">"$attempt_score"</span> <span class="na">failingResult=</span><span class="s">"0"</span><span class="nt">&gt;</span>
+  <span class="nt">&lt;rubric</span> <span class="na">type=</span><span class="s">"pass-fail"</span> <span class="na">passingAttemptScore=</span><span class="s">"80"</span> <span class="na">passedResult=</span><span class="s">"$attempt_score"</span> <span class="na">failedResult=</span><span class="s">"0"</span><span class="nt">&gt;</span>
     <span class="nt">&lt;mods&gt;</span>
       <span class="nt">&lt;mod</span> <span class="na">attemptCondition=</span><span class="s">"1"</span> <span class="na">reward=</span><span class="s">"5"</span> <span class="nt">/&gt;</span>
     <span class="nt">&lt;/mods&gt;</span>

--- a/releases/v3.3.2/authors/assessment_lti_replace_result.md
+++ b/releases/v3.3.2/authors/assessment_lti_replace_result.md
@@ -22,7 +22,7 @@ Obojobo normally sends the [Overall Assessment Score](assessment_scoring.html#ov
 
 The {{ 'rubric' | obo_node }} attributes can be configured to conditionally send scores when they are above a value.
 
-Set the {{ 'rubric' | obo_node }} attribute `failingResult="no-score"` to prevent any score below the value of `passingAttemptScore` from being sent to the LMS.
+Set the {{ 'rubric' | obo_node }} attribute `failedResult="no-score"` to prevent any score below the value of `passingAttemptScore` from being sent to the LMS.
 
 This can be useful when the assignment in the LMS is used to prevent access to other parts of the course. By not sending a score back, the LMS will not unlock content that requires a passing score.
 
@@ -34,8 +34,8 @@ This can be useful when the assignment in the LMS is used to prevent access to o
       <rubric
         type="pass-fail"
         passingAttemptScore="75"
-        passingResult="$attempt_score"
-        failingResult="no-score"
+        passedResult="$attempt_score"
+        failedResult="no-score"
       />
 
       <!-- ... -->
@@ -59,8 +59,8 @@ In this example the highest failing attempt score will be sent.
       <rubric
         type="pass-fail"
         passingAttemptScore="75"
-        passingResult="$attempt_score"
-        failingResult="no-score"
+        passedResult="$attempt_score"
+        failedResult="no-score"
         unableToPassResult="$highest_attempt_score"
       />
 
@@ -85,8 +85,8 @@ ScoreAction Pages can be added for all three conditions:
       <rubric
         type="pass-fail"
         passingAttemptScore="75"
-        passingResult="$attempt_score"
-        failingResult="no-score"
+        passedResult="$attempt_score"
+        failedResult="no-score"
         unableToPassResult="$highest_attempt_score"
       />
 
@@ -110,7 +110,7 @@ How does the logic matches those three conditions?
 
 When failing with attempts remaining the `for="no-score"` is always matched.
 
-`passingAttemptScore` is set to 75, and the `passingResult` is set to the `$attempt_score` variable. This means in a passing condition, the score will be **75+**, matching `for="[75,100]"`.
+`passingAttemptScore` is set to 75, and the `passedResult` is set to the `$attempt_score` variable. This means in a passing condition, the score will be **75+**, matching `for="[75,100]"`.
 
 Failing with no attempts remaining won't match `for="no-score"` because the `unableToPassResult` attribute is set to a variable that will report a score. This means that when the student runs out of attempts, failing every time, the score will be recorded based on their highest attempt score. This score will be 0-75, so the `for="[0,75)"` condition is matched.
 

--- a/releases/v3.3.2/authors/assessment_threshold_scoring.md
+++ b/releases/v3.3.2/authors/assessment_threshold_scoring.md
@@ -5,7 +5,7 @@ menus: authors_assessments_how_to
 
 Assessment Rubric's `'pass-fail'` type can optionally be used to create a threshold type scoring system.
 
-For example, an assessment can require a score of 75% or higher to pass. When the `passingAttemptScore` is reached, the student's score will be adjusted to the `passingResult` value.
+For example, an assessment can require a score of 75% or higher to pass. When the `passingAttemptScore` is reached, the student's score will be adjusted to the `passedResult` value.
 
 In this example, when the student scores below 75%, the score will be adjusted to 0. When the student's score is 75% or higher, the score will be adjusted to `100%`.
 
@@ -18,8 +18,8 @@ In this example, when the student scores below 75%, the score will be adjusted t
       <rubric
         type="pass-fail"
         passingAttemptScore="75"
-        passingResult="100"
-        failingResult="0"
+        passedResult="100"
+        failedResult="0"
       />
 
       <!-- ... -->
@@ -37,8 +37,8 @@ This feature can be combined with Score Action Pages to display specialized mess
       <rubric
         type="pass-fail"
         passingAttemptScore="75"
-        passingResult="100"
-        failingResult="0"
+        passedResult="100"
+        failedResult="0"
       />
 
       <scoreActions>

--- a/releases/v3.3.2/developers/obo_nodes/assessment.md
+++ b/releases/v3.3.2/developers/obo_nodes/assessment.md
@@ -137,7 +137,7 @@ Assessment expects exactly two children in order:
   <QuestionBank choose="3" select="random">
     <!-- ... -->
   </QuestionBank>
-  <rubric type="pass-fail" passingAttemptScore="80" passingResult="$attempt_score" failingResult="0">
+  <rubric type="pass-fail" passingAttemptScore="80" passedResult="$attempt_score" failedResult="0">
     <mods>
       <mod attemptCondition="1" reward="5" />
     </mods>


### PR DESCRIPTION
Replaces the incorrect terms 'failingResult' and 'passingResult' with the correct terms 'failedResult' and 'passedResult'.