### PR TITLE
Updates for dev/20

### DIFF
--- a/releases/v12.1.0/developers/events/obojobo_events.md
+++ b/releases/v12.1.0/developers/events/obojobo_events.md
@@ -235,7 +235,7 @@ Occurs when the user or ViewerClient has hidden a question explanation.
 
 <dl>
 	<dt>Version</dt>
-	<dd>1.1.0</dd>
+	<dd>1.2.0</dd>
 </dl>
 
 #### Payload
@@ -243,6 +243,7 @@ Occurs when the user or ViewerClient has hidden a question explanation.
 | Property | Description |
 |-
 | questionId | The id of the corresponding Question
+| context | The context (string) when the explanation was shown
 | actor | Either `'user'` or `'viewerClient'`
 
 ### _question:checkAnswer_
@@ -263,6 +264,22 @@ Occurs when the user is checking their answer to a graded question.
 | response | The state of the response of the question
 | scoreId | Internal id of the question score
 | score | The score value (0-100)
+
+### _question:revealAnswer_
+
+Occurs when the user clicks the Reveal Answer button
+
+<dl>
+	<dt>Version</dt>
+	<dd>1.0.0</dd>
+</dl>
+
+#### Payload
+
+| Property | Description |
+|-
+| questionId | The id of the corresponding Question
+| context | The context (string) when the user is checking their answer
 
 ### _question:submitResponse_
 
@@ -303,7 +320,7 @@ Occurs when the user has selected a response to a question.
 
 <dl>
 	<dt>Version</dt>
-	<dd>2.1.0</dd>
+	<dd>2.2.0</dd>
 </dl>
 
 #### Payload
@@ -311,8 +328,9 @@ Occurs when the user has selected a response to a question.
 | Property | Description |
 |-
 | questionId | The id of the corresponding Question
-| targetId | The id of the OboNode item that was interacted with
+| targetId | The id of the OboNode item that was interacted with, if it exists. Otherwise `null`.
 | response | The state of the response of the question
+| sendResponseImmediately | If true then this event was sent as soon as the user created this response. If false then the event was sent sometime after the response was captured.
 | context |
 | assessmentId |
 | attemptId |

--- a/releases/v12.1.0/developers/obo_nodes/mc_assessment.md
+++ b/releases/v12.1.0/developers/obo_nodes/mc_assessment.md
@@ -13,9 +13,15 @@ This is the multiple choice portion of a question containing several answer choi
 | Property | Required | Type | Description |
 |-
 | responseType | no | String | Default: `pick-one`. Defines what type of multiple choice question this is. Possible values are enumerated below.
+| shuffle | no | Boolean | Default: `true`. If `false` then the answer choices will be listed in document order. Otherwise answer choices will be shuffled.
+
+## Deprecated Properties
+
+| Property | Required | Type | Description |
 | correctLabels | no | String | Default: `Correct!|You got it!|Great job!|That's right!` for default questions, `Response recorded` for survey questions. A `|` seperated list of labels to display when a non-assessment Question is answered correctly. One label will be selected at random. In Assessment Review this value is ignored (`'Correct!'` is always displayed instead for default questions, and `'Response recorded'` is always displayed for survey questions).
 | incorrectLabels | no | String | Default: `Incorrect`. A `|` seperated list of labels to display when a non-assessment Question is answered incorrectly. One label will be selected at random. This value is ignored for survey questions.
-| shuffle | no | Boolean | Default: `true`. If `false` then the answer choices will be listed in document order. Otherwise answer choices will be shuffled.
+
+> These properties in version 12.0.0 and earlier were defined on MCAssessment nodes, but now should be defined on {{ 'Question' | obo_node }} nodes.
 
 ### Supported Values for 'responseType'
 

--- a/releases/v12.1.0/developers/obo_nodes/numeric_answer.md
+++ b/releases/v12.1.0/developers/obo_nodes/numeric_answer.md
@@ -1,0 +1,109 @@
+---
+title: NumericAssessment > NumericChoice > NumericAnswer
+menus: chunks
+full_name: ObojoboDraft.Chunks.NumericAssessment.NumericAnswer
+class: obo_node
+node_class: chunk
+---
+
+This represents one possible answer (correct or incorrect) for a numeric question.
+
+## Properties
+
+| Property | Required | Type | Description |
+|-
+| requirement | Recommended | String | Default: "exact". Determines how to potentially match student input to this answer choice.
+
+## Supported values for requirement
+
+| Requirement Type | Description |
+|-
+| exact | Exact means that only student responses that represent the exact same value are allowed. For example, an exact answer of `4` will match against student responses for `4`, `4.0`, `8/2`, but not for `4.01`.
+| range | Range accepts a range of answers, for example, all numbers -1 to 1. This would match student responses of `-1`, `1`, `0`, `1/1`, `1/2`, but not `-1.1` or `2` for example.
+| margin | Margin allows you to define an answer with an accepted margin of error - either absolute or percent error. For example, an answer of `100` with a 5% margin of error would accept student responses for `100` as well as `100.2`, but not `120`.
+
+## Additional properties when requirement is "exact"
+
+| Property | Required | Type | Description |
+|-
+| answer | Required | Answer String | The numeric value of this answer choice
+
+## Additional properties when requirement is "range"
+
+| Property | Required | Type | Description |
+|-
+| start | Required | Answer String | The starting numeric value for this answer range
+| end | Required | Answer String | The ending numeric value for this answer range
+
+## Additional properties when requirement is "margin"
+
+| Property | Required | Type | Description |
+|-
+| answer | Required | Answer String | The numeric value of this answer choice
+| type | Required | String | The type of error, percent or absolute
+| margin | Required | String | Either the percent or absolute error amount allowed
+
+## Format of Answer Strings
+
+Answers can be decimal numbers, in scientific notation, fractions, hexadecimal numbers, octal numbers or binary numbers. Leading zeroes are ignored. Some examples are provided:
+
+| Answer string example | Parsed as | Subtype | Equivalent decimal value | Note
+|-
+| 0 | decimal || 0 |
+| 01.230 | decimal || 1.230 | Trailing zeroes are kept for significant figure purposes
+| 100. | decimal || 100. | Trailing "." is kept for significant figure purposes
+| 1/2 | fraction || 0.5 |
+| -2/4 | fraction || -0.5 | Non-reduced fractions are allowed
+| 1/3 | fraction || 0.333333... |
+| 6.02e24 | scientific | e | 6020000000000000000000000 |
+| 60.2e23 | scientific | e | 6020000000000000000000000 | Improper form (more than one digit to the left of the decimal) is allowed
+| 6.02\*10^24 | scientific | asterix | 6020000000000000000000000 |
+| 6.02ee24 | scientific | ee | 6020000000000000000000000 |
+| 6.02'24 | scientific | apos | 6020000000000000000000000 |
+| 6.02x10^24 | scientific | x | 6020000000000000000000000 |
+| 0xFF0F | hexadecimal | hexZeroX | 65295 |
+| #FF0F | hexadecimal | hexOctothorpe | 65295 |
+| $FF0F | hexadecimal | hexDollarSign | 65295 |
+| 0o777 | octal || 511 |
+| 0b1101 | binary || 13 |
+
+Student input is matched to potential answer values by checking the equivalent decimal value. For example, if a possible answer value is "2", student input of "2/1" is still accepted as a match as it is equivalent in value. An additional special case is afforded for fractional equivalency. If an answer value is "1/3", student input of "0.333333" (or the same input with additional 3s) is considered equivalent ("0.33333" - an answer with five "3"s - is not). Likewise, student input of "1/3" will match against an answer value of "0.333333".
+
+## Supported Trigger Types
+
+| Action Type | Description
+|-
+| onMount | Fired when a node is added to the DOM
+| onUnmount | Fired when a node is removed from the DOM
+
+## Required Children
+
+None
+
+## Variables Registered
+
+None
+
+## Example
+
+### JSON
+
+```json
+{
+	"type": "ObojoboDraft.Chunks.NumericAssessment.NumericAnswer",
+	"id": "...",
+	"content": [
+		{
+			"requirement": "range",
+			"start": "-1",
+			"end": "1"
+		}
+	]
+}
+```
+
+### XML
+
+```xml
+<NumericAnswer requirement="range" start="-1" end="1" />
+```

--- a/releases/v12.1.0/developers/obo_nodes/numeric_assessment.md
+++ b/releases/v12.1.0/developers/obo_nodes/numeric_assessment.md
@@ -1,0 +1,76 @@
+---
+title: NumericAssessment
+menus: chunks
+full_name: ObojoboDraft.Chunks.NumericAssessment
+class: obo_node
+node_class: chunk
+---
+
+This is the input-a-number portion of a question containing several answer choices.
+
+## Properties
+
+| Property | Required | Type | Description |
+|-
+| units | no | {{ 'textGroup' | obo_node }} | An optional one-item TextGroup - this text will be displayed after the answer input.
+
+## Supported Trigger Types
+
+| Action Type | Description
+|-
+| onMount | Fired when a node is added to the DOM
+| onUnmount | Fired when a node is removed from the DOM
+
+## Required Children
+
+Zero or more {{ 'NumericChoice' | obo_node }} nodes.
+
+## Variables Registered
+
+None
+
+## Example
+
+### JSON
+
+```json
+{
+	"type": "ObojoboDraft.Chunks.NumericAssessment",
+	"id": "...",
+	"content": {
+		"units": [{ "text": { "value": "grams" } }]
+	},
+	"children": [
+		{
+			"type": "ObojoboDraft.Chunks.NumericAssessment.NumericChoice",
+			"id": "...",
+			"content": {
+				"score": 100
+			},
+			"children": [
+				{
+					"type": "ObojoboDraft.Chunks.NumericAssessment.NumericAnswer",
+					"id": "...",
+					"content": {
+						"answer": "4",
+						"requirement": "exact"
+					}
+				}
+			]
+		}
+	]
+}
+```
+
+### XML
+
+```xml
+<NumericAssessment>
+  <units>
+    <textGroup><t>grams</t></textGroup>
+  </units>
+  <NumericChoice score="100">
+    <NumericAnswer answer="4" requirement="exact" />
+  </NumericChoice>
+</NumericAssessment>
+```

--- a/releases/v12.1.0/developers/obo_nodes/numeric_choice.md
+++ b/releases/v12.1.0/developers/obo_nodes/numeric_choice.md
@@ -1,0 +1,67 @@
+---
+title: NumericAssessment > NumericChoice
+menus: chunks
+full_name: ObojoboDraft.Chunks.NumericAssessment.NumericChoice
+class: obo_node
+node_class: chunk
+---
+
+A single answer choice in a multiple choice question containing the contents of the answer and optional feedback. Feedback is not displayed in an Assessment Attempt Quiz but is displayed outside Assessment or in Assessment Review (when full Assessment Review is being shown).
+
+## Properties
+
+| Property | Required | Type | Description |
+|-
+| score | Required | Integer | `0` or `100`: Represents the correctness of this answer choice - i.e. A correct answer should have a `score` of `100` and incorrect answers a `score` of `0`.
+
+> Partial credit is not supported - values must be either `0` or `100`, not a value in-between. A future release may allow for partial credit.
+
+## Supported Trigger Types
+
+| Action Type | Description
+|-
+| onMount | Fired when a node is added to the DOM
+| onUnmount | Fired when a node is removed from the DOM
+
+## Required Children
+
+Expects one or two children in order:
+
+1.  **REQUIRED**: An {{ 'NumericAnswer' | obo_node }} OboNode.
+2.  An {{ 'NumericFeedback' | obo_node }} OboNode. This is not displayed in an Assessment Attempt Quiz but is displayed outside Assessment or in Assessment Review (when full Assessment Review is being shown).
+
+## Variables Registered
+
+None
+
+## Example
+
+### JSON
+
+```json
+{
+	"type": "ObojoboDraft.Chunks.NumericAssessment.NumericChoice",
+	"id": "...",
+	"content": {
+		"score": 100
+	},
+	"children": [
+		{
+			"type": "ObojoboDraft.Chunks.NumericAssessment.NumericAnswer",
+			"id": "...",
+			"content": {
+				"answer": "4",
+				"requirement": "exact"
+			}
+		}
+	]
+}
+```
+
+### XML (with OboHTML)
+
+```xml
+<NumericChoice score="100">
+	<NumericAnswer answer="4" requirement="exact" />
+</NumericChoice>
+```

--- a/releases/v12.1.0/developers/obo_nodes/numeric_feedback.md
+++ b/releases/v12.1.0/developers/obo_nodes/numeric_feedback.md
@@ -1,0 +1,62 @@
+---
+title: NumericAssessment > NumericChoice > NumericFeedback
+menus: chunks
+full_name: ObojoboDraft.Chunks.NumericAssessment.NumericFeedback
+class: obo_node
+node_class: chunk
+---
+
+This represents the contents of the feedback of a numeric answer choice.
+
+## Properties
+
+None
+
+## Supported Trigger Types
+
+| Action Type | Description
+|-
+| onMount | Fired when a node is added to the DOM
+| onUnmount | Fired when a node is removed from the DOM
+
+## Required Children
+
+One or more of the following Chunks: {% include obo_nodes_that_can_be_in_a_question.md %}.
+
+## Variables Registered
+
+None
+
+## Example
+
+### JSON
+
+```json
+{
+	"type": "ObojoboDraft.Chunks.NumericAssessment.NumericFeedback",
+	"id": "...",
+	"children": [
+		{
+			"type": "ObojoboDraft.Chunks.Text",
+			"id": "...",
+			"content": {
+				"textGroup": [
+					{
+						"text": {
+							"value": "Example Feedback"
+						}
+					}
+				]
+			}
+		}
+	]
+}
+```
+
+### XML (With OboHTML)
+
+```xml
+<NumericFeedback>
+  <p>Example Feedback</p>
+</NumericFeedback>
+```

--- a/releases/v12.1.0/developers/obo_nodes/question.md
+++ b/releases/v12.1.0/developers/obo_nodes/question.md
@@ -14,6 +14,18 @@ Either an assessment or practice question. Questions are designed to support mul
 |-
 | type | no | String | Default: `default`. Must be either `default` or `survey`. `survey` will create an un-graded question, all other values will create a standard practice or assessment question.
 | solution | no | {{ 'Page' | obo_node }} | A page containing a full-text description of the solution to the problem. If this is set a button will be available after the question is attempted which will reveal the solution if pressed. This button is only available for `default` type questions and is hidden when the question is used in an assessment (but will show up in a full assessment review).
+| revealAnswer | no | String | Default: `default`. Determines when the "Reveal Answer" button should be displayed for practice questions.
+| correctLabels | no | String | Default: `Correct!|You got it!|Great job!|That's right!` for default questions, `Response recorded` for survey questions. A `|` seperated list of labels to display when a non-assessment Question is answered correctly. One label will be selected at random. In Assessment Review this value is ignored (`'Correct!'` is always displayed instead for default questions, and `'Response recorded'` is always displayed for survey questions).
+| incorrectLabels | no | String | Default: `Incorrect`. A `|` seperated list of labels to display when a non-assessment Question is answered incorrectly. One label will be selected at random. This value is ignored for survey questions.
+
+## Supported values for `revealAnswer`
+
+| Type Name | Description |
+|-
+| default | Allow the type of question to determine when/if to show the Reveal Answer button (never for Multiple Choice questions, when-incorrect for Numeric questions)
+| never | The button will never be shown for this question
+| always | The button will be shown when the question is unanswered or if answered incorrectly
+| when-incorrect | The button will only be shown when a question is answered incorrectly
 
 ## Supported Trigger Types
 
@@ -25,7 +37,7 @@ Either an assessment or practice question. Questions are designed to support mul
 ## Required Children
 
 1.  One or more [Chunk nodes](../#chunk) ({% include obo_nodes_that_can_be_in_a_question.md %}) - This is how you create the actual question
-2.  An {{ 'MCAssessment' | obo_node }} node - this MUST be the last child.
+2.  An {{ 'MCAssessment' | obo_node }} or {{ 'NumericAssessment' | obo_node }} node - this MUST be the last child.
 
 ## Variables Registered
 


### PR DESCRIPTION
* Adds `question:revealAnswer`
* Updates `question:hideExplanation`
* Updates `question:setResponse`
* Deprecates `correctLabels` and `incorrectLabels` in MCAssessment
* Adds `revealAnswer`, `correctLabels` and `incorrectLabels` to Question
* Adds NumericAssessment, NumericChoice, NumericAnswer, NumericFeedback